### PR TITLE
chore: update WordPress tested version to 6.9

### DIFF
--- a/omnisend-for-contact-form-7/class-wpcf7-omnisend-bootstrap.php
+++ b/omnisend-for-contact-form-7/class-wpcf7-omnisend-bootstrap.php
@@ -4,7 +4,7 @@
  *
  * Plugin Name: Omnisend for Contact Form 7 Add-On
  * Description: A Contact Form 7 add-on to sync contacts with Omnisend. In collaboration with Omnisend for WooCommerce plugin it enables better customer tracking
- * Version: 1.1.5
+ * Version: 1.1.6
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
  * Developer: Omnisend
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'wpcf7_init', array( 'WPCF7_Omnisend_Bootstrap', 'load' ), 5 );
 
 const WPCP7_OMNISEND_PLUGIN_NAME                     = 'Omnisend for Contact Form 7';
-const WPCP7_OMNISEND_PLUGIN_VERSION                  = '1.1.5';
+const WPCP7_OMNISEND_PLUGIN_VERSION                  = '1.1.6';
 const WPCP7_OMNISEND_SUPPORT_ARTICLE_LINK            = 'https://support.omnisend.com/en/articles/8672359-integration-with-contact-form-7';
 const WPCP7_OMNISEND_WELCOME_AUTOMATION_ARTICLE_LINK = 'https://support.omnisend.com/en/articles/1061818-welcome-email-automation';
 

--- a/omnisend-for-contact-form-7/readme.txt
+++ b/omnisend-for-contact-form-7/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Contact Form 7 Add-On
 Contributors: omnisend
 Tags: Contact Form 7, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 7.1
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -63,6 +63,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.1.6 =
+* Tested up to WordPress 6.9
 
 = 1.1.5 =
 * Update screenshots


### PR DESCRIPTION
## What?
Update WordPress tested version to 6.9 and bump plugin version to 1.1.6.

## Why?
Plugin has been tested with WordPress 6.9.